### PR TITLE
support decode clustered index row key

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -76,7 +76,7 @@ func DecodeRocksDBKey(n *Node) *Variant {
 }
 
 func DecodeTablePrefix(n *Node) *Variant {
-	if n.typ == "key" && len(n.val) == 9 && n.val[0] == 't' {
+	if n.typ == "key" && len(n.val) >= 9 && n.val[0] == 't' {
 		return &Variant{
 			method:   "table prefix",
 			children: []*Node{N("table_id", n.val[1:])},
@@ -86,10 +86,14 @@ func DecodeTablePrefix(n *Node) *Variant {
 }
 
 func DecodeTableRow(n *Node) *Variant {
-	if n.typ == "key" && len(n.val) == 19 && n.val[0] == 't' && n.val[9] == '_' && n.val[10] == 'r' {
+	if n.typ == "key" && len(n.val) >= 19 && n.val[0] == 't' && n.val[9] == '_' && n.val[10] == 'r' {
+		handleTyp := "index_values"
+		if remain, _, err := codec.DecodeInt(n.val[11:]); err == nil && len(remain) == 0 {
+			handleTyp = "row_id"
+		}
 		return &Variant{
 			method:   "table row key",
-			children: []*Node{N("table_id", n.val[1:9]), N("row_id", n.val[11:])},
+			children: []*Node{N("table_id", n.val[1:9]), N(handleTyp, n.val[11:])},
 		}
 	}
 	return nil


### PR DESCRIPTION
closes #8, Support decode clustered index's Row Key

clustered index's handle could be:

- int: row_id
- not int: encoded index values for primary key columns

so just, try int first, and try decode as index value

```
// primary key(int, int)

 ./mok 7480000000000000355F72040000000000000001040000000000000002
"7480000000000000355F72040000000000000001040000000000000002"
└─## decode hex key
  └─"t\200\000\000\000\000\000\0005_r\004\000\000\000\000\000\000\000\001\004\000\000\000\000\000\000\000\002"
    ├─## table prefix
    │ └─table: 53
    └─## table row key
      ├─table: 53
      └─"\004\000\000\000\000\000\000\000\001\004\000\000\000\000\000\000\000\002"
        └─## decode index values
          ├─kind: Uint64, value: 1
          └─kind: Uint64, value: 2

// primary key(varchar)

./mok 74800000000000003E5F72013100000000000000F8
"74800000000000003E5F72013100000000000000F8"
└─## decode hex key
  └─"t\200\000\000\000\000\000\000>_r\0011\000\000\000\000\000\000\000\370"
    ├─## table prefix
    │ └─table: 62
    └─## table row key
      ├─table: 62
      └─"\0011\000\000\000\000\000\000\000\370"
        └─## decode index values
          └─kind: Bytes, value: 1


// primary key (int)

./mok 7480000000000000415F728000000000000002
"7480000000000000415F728000000000000002"
└─## decode hex key
  └─"t\200\000\000\000\000\000\000A_r\200\000\000\000\000\000\000\002"
    ├─## table prefix
    │ └─table: 65
    └─## table row key
      ├─table: 65
      └─row: 2
```