### PR TITLE
Support keyspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ $ ./mok --table-id 43 --index-id 50 --index-value 81934
 built key: 7480000000000000FF2B5F698000000000FF0000328000000000FF01400E0000000000FA
 ```
 
+Build a key for a given record under given keyspace
+```
+$ ./mok --keyspace-id 255 --table-id 43 --row-value 81934
+built key: 780000FF74800000FF000000002B5F7280FF0000000001400E00FE
+```
+
 ## TODO
 
 - [x] build keys

--- a/mok.go
+++ b/mok.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -37,6 +38,11 @@ func (n *Node) String() string {
 		default:
 			return fmt.Sprintf("%q", n.val)
 		}
+	case "keyspace_id":
+		tmp := []byte{'\x00'}
+		t := append(tmp, n.val...)
+		id := binary.BigEndian.Uint32(t)
+		return fmt.Sprintf("keyspace: %v", id)
 	case "table_id":
 		_, id, _ := codec.DecodeInt(n.val)
 		return fmt.Sprintf("table: %v", id)

--- a/rules.go
+++ b/rules.go
@@ -19,6 +19,7 @@ func init() {
 		DecodeHex,
 		DecodeComparableKey,
 		DecodeRocksDBKey,
+		DecodeKeyspace,
 		DecodeTablePrefix,
 		DecodeTableRow,
 		DecodeTableIndex,
@@ -74,6 +75,16 @@ func DecodeRocksDBKey(n *Node) *Variant {
 		return &Variant{
 			method:   "decode rocksdb data key",
 			children: []*Node{N("key", n.val[1:])},
+		}
+	}
+	return nil
+}
+
+func DecodeKeyspace(n *Node) *Variant {
+	if n.typ == "key" && n.val[0] == 'x' && len(n.val) >= 4 {
+		return &Variant{
+			method:   "decode keyspace",
+			children: []*Node{N("keyspace_id", n.val[1:4]), N("key", n.val[4:])},
 		}
 	}
 	return nil


### PR DESCRIPTION
tested:

```
>  ./releases/mok 78000DA274800000FF00000005E25F7280FF0000028BFD5BCB00FE
"78000DA274800000FF00000005E25F7280FF0000028BFD5BCB00FE"
└─## decode hex key
  └─"x\000\r\242t\200\000\000\377\000\000\000\005\342_r\200\377\000\000\002\213\375[\313\000\376"
    ├─## decode mvcc key
    │ └─"x\000\r\242t\200\000\000\000\000\000\005\342_r\200\000\000\002\213\375[\313"
    │   └─## decode keyspace
    │     ├─keyspace: 3490
    │     └─"t\200\000\000\000\000\000\005\342_r\200\000\000\002\213\375[\313"
    │       ├─## table prefix
    │       │ └─table: 1506
    │       └─## table row key
    │         ├─table: 1506
    │         └─row: 10938571723
    └─## decode keyspace
      ├─keyspace: 3490
      └─"t\200\000\000\377\000\000\000\005\342_r\200\377\000\000\002\213\375[\313\000\376"
        └─## table prefix
          └─table: 1095216660485

>  ./releases/mok 78000DA274800000FF00000005E25F7280FF0000028EC3DB6900FE
"78000DA274800000FF00000005E25F7280FF0000028EC3DB6900FE"
└─## decode hex key
  └─"x\000\r\242t\200\000\000\377\000\000\000\005\342_r\200\377\000\000\002\216\303\333i\000\376"
    ├─## decode mvcc key
    │ └─"x\000\r\242t\200\000\000\000\000\000\005\342_r\200\000\000\002\216\303\333i"
    │   └─## decode keyspace
    │     ├─keyspace: 3490
    │     └─"t\200\000\000\000\000\000\005\342_r\200\000\000\002\216\303\333i"
    │       ├─## table prefix
    │       │ └─table: 1506
    │       └─## table row key
    │         ├─table: 1506
    │         └─row: 10985134953
    └─## decode keyspace
      ├─keyspace: 3490
      └─"t\200\000\000\377\000\000\000\005\342_r\200\377\000\000\002\216\303\333i\000\376"
        └─## table prefix
          └─table: 1095216660485
```